### PR TITLE
+ Added Monad Transformer for Twitter Future and Scalactic Or

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,7 @@ local.properties
 # TeXlipse plugin
 .texlipse
 
+# Ensime
+.ensime
+.ensime_cache
+

--- a/hamsters-twitter-util/build.sbt
+++ b/hamsters-twitter-util/build.sbt
@@ -5,6 +5,7 @@ version := "1.0.0-SNAPSHOT"
 scalaVersion := "2.11.8"
 
 libraryDependencies ++= Seq(
-  "com.twitter" %% "util-core" % "6.33.0",
+  "org.scalactic" %% "scalactic" % "2.2.6",
+  "com.twitter" %% "util-core" % "6.34.0",
   "org.scalatest" %% "scalatest" % "2.2.6" % "test"
 )


### PR DESCRIPTION
Scalactic provides a very power design: Or. Or can be a replacement of `Either` type and accumulates error types.
With this addition, hamster can provide a Monad Transformer for Twitter Future and Scalactic Or.

http://www.scalactic.org
